### PR TITLE
Fix uses of JSONStreamParser

### DIFF
--- a/Worker.js
+++ b/Worker.js
@@ -19,7 +19,6 @@ function Worker(workerPath, workerArgs, options) {
   this._opts = options;
   this._pendingResponseDeferred = null;
   this._stderrData = '';
-  this._stdoutData = '';
   this._streamParser = new JSONStreamParser();
   this._workerArgs = workerArgs;
   this._workerPath = workerPath;
@@ -66,10 +65,7 @@ Worker.prototype._onChildExit = function(code, signalStr) {
   var errorMsg =
     ' exit code: ' + code + ', exit signal: ' + signalStr + '\n' +
     'stderr:\n' +
-    '  ' + this._stderrData.trim() + '\n' +
-    '\n' +
-    'stdout:\n' +
-    '  ' + this._stdoutData.trim();
+    '  ' + this._stderrData.trim() + '\n';
 
   if (this._initialized === false) {
     throw new Error(
@@ -97,13 +93,11 @@ Worker.prototype._onStdout = function(data) {
     throw new Error('Received unexpected data from child process: ' + data);
   }
 
-  this._stdoutData += data;
-
   var responses;
   try {
-    responses = this._streamParser.parse(this._stdoutData);
+    responses = this._streamParser.parse(data);
   } catch (e) {
-    e = new Error('Unable to parse child response data: ' + this._stdoutData);
+    e = new Error('Unable to parse child response data: ' + this._streamParser.getBuffer());
     if (this._initialized === false) {
       throw e;
     } else {

--- a/lib/JSONStreamParser.js
+++ b/lib/JSONStreamParser.js
@@ -1,46 +1,44 @@
 "use strict";
 
-function JSONStreamParser(initialStreamOffset) {
+function JSONStreamParser() {
   this._currentlyWithinQuotedString = false;
-  this._currentObjectHead = 0;
-  this._cursorPosition = initialStreamOffset || 0;
   this._depth = 0;
-  this._leftOverStreamText = '';
+  this._buffer = '';
 }
 
 JSONStreamParser.prototype.parse=function(streamText) {
+  var cursor = this._buffer.length;
+  this._buffer += streamText;
   var currChar;
   var responses = [];
-  while (this._cursorPosition < streamText.length) {
-    currChar = streamText.charAt(this._cursorPosition);
+  while (cursor < this._buffer.length) {
+    currChar = this._buffer.charAt(cursor);
     if (this._currentlyWithinQuotedString && currChar === '\\') {
       // If the current character is escaped, move forward
-      this._cursorPosition++;
+      cursor++;
     } else if (currChar === '"') {
       // Are we inside a quoted string?
       this._currentlyWithinQuotedString = !this._currentlyWithinQuotedString;
     } else if (!this._currentlyWithinQuotedString) {
       if (currChar === '{') {
-        if (this._depth === 0) {
-          this._currentObjectHead = this._cursorPosition;
-        }
         this._depth++;
       } else if (currChar === '}') {
         this._depth--;
         if (this._depth === 0) {
-          responses.push(JSON.parse(
-            streamText.substring(
-              this._currentObjectHead,
-              this._cursorPosition + 1
-            )
-          ));
+          responses.push(JSON.parse(this._buffer.substring(0, cursor + 1)));
+          this._buffer = this._buffer.substring(cursor + 1);
+          cursor = 0;
+          continue;
         }
       }
     }
-    this._cursorPosition++;
+    cursor++;
   }
   return responses;
 };
 
+JSONStreamParser.prototype.getBuffer=function() {
+  return this._buffer;
+}
 
 module.exports = JSONStreamParser;

--- a/lib/__tests__/JSONStreamParser.js
+++ b/lib/__tests__/JSONStreamParser.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ */
+
+/**
+ * @emails jeffmo@fb.com
+ */
+
+require('mock-modules').autoMockOff();
+
+describe('JSONStreamParser', function() {
+  var JSONStreamParser = require('../JSONStreamParser');
+
+  describe('the basics', function() {
+    it('handles a single empty object', function() {
+      var parser = new JSONStreamParser();
+      expect(parser.parse('{}')).toEqual([{}]);
+    });
+
+    it('handles multiple empty objects', function() {
+      var parser = new JSONStreamParser();
+      expect(parser.parse('{}{}')).toEqual([{}, {}]);
+    });
+
+    it('handles a flat key-value object', function() {
+      var parser = new JSONStreamParser();
+      expect(parser.parse('{"TEST_KEY":"TEST_VALUE"}')).toEqual([
+        {TEST_KEY: "TEST_VALUE"}
+      ]);
+    });
+
+    it('handles multiple flat key-value objects', function() {
+      var parser = new JSONStreamParser();
+      expect(parser.parse('{"OBJ1":"VAL1"}{"OBJ2":"VAL2"}')).toEqual([
+        {OBJ1: "VAL1"},
+        {OBJ2: "VAL2"}
+      ]);
+    });
+
+    it('handles a stream of a single empty object', function() {
+      var parser = new JSONStreamParser();
+      var partialStream1 = '{';
+      var partialStream2 = '}';
+      expect(parser.parse(partialStream1)).toEqual([]);
+      expect(parser.parse(partialStream2)).toEqual([{}]);
+    });
+
+    it('handles a stream of multiple empty objects', function() {
+      var parser = new JSONStreamParser();
+      var partialStream1 = '{}{';
+      var partialStream2 = '}';
+      expect(parser.parse(partialStream1)).toEqual([{}]);
+      expect(parser.parse(partialStream2)).toEqual([{}]);
+    });
+
+    it('handles a stream of a single flat object', function() {
+      var parser = new JSONStreamParser();
+      var partialStream1 = '{"OBJECT1';
+      var partialStream2 = '":true}';
+      expect(parser.parse(partialStream1)).toEqual([]);
+      expect(parser.parse(partialStream2)).toEqual([{OBJECT1: true}]);
+    });
+
+    it('handles stream of multiple flat objects', function() {
+      var parser = new JSONStreamParser();
+      var partialStream1 = '{"OBJECT1":true}{"OBJE';
+      var partialStream2 = 'CT2":true}';
+      expect(parser.parse(partialStream1)).toEqual([{OBJECT1: true}]);
+      expect(parser.parse(partialStream2)).toEqual([{OBJECT2: true}]);
+    });
+
+    it('handles a stream of a single nested object', function() {
+      var parser = new JSONStreamParser();
+      var partialStream1 = '{"OBJECT1":{"OBJE';
+      var partialStream2 = 'CT2":true}}';
+      expect(parser.parse(partialStream1)).toEqual([]);
+      expect(parser.parse(partialStream2)).toEqual([
+        {OBJECT1: {OBJECT2: true}}
+      ]);
+    });
+
+    it('handles a stream of multiple nested objects', function() {
+      var parser = new JSONStreamParser();
+      var partialStreams = [
+        '{"OBJECT1":{"OBJECT2":true}}{"OBJECT3',
+        '":{"OBJECT4"',
+        ':true}}'
+      ];
+      expect(parser.parse(partialStreams[0])).toEqual([
+        {OBJECT1: {OBJECT2: true}}
+      ]);
+      expect(parser.parse(partialStreams[1])).toEqual([]);
+      expect(parser.parse(partialStreams[2])).toEqual([
+        {OBJECT3: {OBJECT4: true}}
+      ]);
+    });
+  });
+
+  it('handles brackets in strings', function() {
+    var parser = new JSONStreamParser();
+    expect(parser.parse('{"}":"{"}')).toEqual([{"}":"{"}]);
+  });
+
+  it('handles escaped quotes in strings', function() {
+    var parser = new JSONStreamParser();
+    expect(parser.parse('{"\\"}":"\\"\\"\\"\\\\\\""}')).toEqual([
+      {"\"}": "\"\"\"\\\""}
+    ]);
+  });
+});

--- a/nodeWorkerUtils.js
+++ b/nodeWorkerUtils.js
@@ -16,15 +16,13 @@ function respondWithResult(result) {
 function startWorker(onInitialize, onMessageReceived, onShutdown) {
   process.stdin.resume();
   process.stdin.setEncoding('utf8');
-  var inputData = '';
   var inputStreamParser = new JSONStreamParser();
 
   var initialized = false;
   var initData = null;
 
   process.stdin.on('data', function(data) {
-    inputData += data;
-    var rcvdMsg = inputStreamParser.parse(inputData);
+    var rcvdMsg = inputStreamParser.parse(data);
     if (rcvdMsg.length === 1) {
       if (initialized === false) {
         try {


### PR DESCRIPTION
Uses of JSONStreamParser were letting the data to be parsed to grow unboundedly.
Fixed JSONStreamParser to maintain its own buffer, allowing callers to supply
it incrementally with data as it comes in. The internal buffer is trimmed
down every time a json object is successfully parsed.
