### PR TITLE
Update docs and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ function onInitialize(data) {
 
 /**
  * Executed each time a message is received from the worker pool.
- * Returns the response to the message (response must always be an object)
+ * Returns the response to the message (response must always be a promise that resolves to an object)
  */
 function onMessage(data) {
-  return {
+  return Promise.resolve({
     initData: initData,
     receivedData: data
-  };
+  });
 }
 
 if (require.main === module) {
@@ -61,8 +61,10 @@ __workerPool.js__
 if (require.main === module) {
   var workerPool = new WorkerPool(
     8,                // number of workers
-    process.execPath, // path to the node binary
-    './worker.js',    // path to the worker script
+    process.execPath, // path to the worker (e.g. node binary)
+    [                 // worker arguments
+      './worker.js',  // e.g. path to the script
+    ],
     {
       // The initData object that is passed to each worker exactly once before
       // any messages get sent. Workers receive this object via their

--- a/nodeWorkerUtils.js
+++ b/nodeWorkerUtils.js
@@ -44,7 +44,7 @@ function startWorker(onInitialize, onMessageReceived, onShutdown) {
               );
             }
             return response;
-          }).done(respondWithResult, respondWithError);
+          }).then(respondWithResult, respondWithError);
         } catch (e) {
           respondWithError(e.stack || e.message);
         }


### PR DESCRIPTION
I have some trouble getting started with node-worker-pool. I found that the README deviates from the implementation and that the implementation expects a non-standard promise implementation.

While I seems to be able to communicate with the worker now, after a while I'm getting this error, but I haven't found out why yet:

```
/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/Worker.js:23
  child.stderr.setEncoding('utf8');
              ^
TypeError: Cannot read property 'setEncoding' of undefined
    at new Worker (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/Worker.js:23:15)
    at WorkerPool._bootNewWorker (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/WorkerPool.js:29:16)
    at WorkerPool._eagerBootAllWorkers (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/WorkerPool.js:4
0:10)
    at new WorkerPool (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/WorkerPool.js:23:10)
    at Object.<anonymous> (/Users/fkling/Dropbox/projects/jsnetworkx/node/_internals/delegate.js:26:18)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/Worker.js:84
    throw new Error(
          ^
Error: Worker process exited before it could be initialized! exit code: 1, exit signal: null
stderr:
  /Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/Worker.js:23
  child.stderr.setEncoding('utf8');
              ^
TypeError: Cannot read property 'setEncoding' of undefined
    at new Worker (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/Worker.js:23:15)
    at WorkerPool._bootNewWorker (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/WorkerPool.js:29:16)
    at WorkerPool._eagerBootAllWorkers (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/WorkerPool.js:4
0:10)
    at new WorkerPool (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/WorkerPool.js:23:10)
    at Object.<anonymous> (/Users/fkling/Dropbox/projects/jsnetworkx/node/_internals/delegate.js:26:18)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)

    at Worker._onChildExit (/Users/fkling/Dropbox/projects/jsnetworkx/node_modules/node-worker-pool/Worker.js:84:11)
    at ChildProcess.emit (events.js:110:17)
```

I will update the PR if needed, if I can resolve this issue.
