### PR TITLE
Use `then` instead of `done` for message promise.

### DIFF
--- a/nodeWorkerUtils.js
+++ b/nodeWorkerUtils.js
@@ -44,7 +44,7 @@ function startWorker(onInitialize, onMessageReceived, onShutdown) {
               );
             }
             return response;
-          }).done(respondWithResult, respondWithError);
+          }).then(respondWithResult, respondWithError);
         } catch (e) {
           respondWithError(e.stack || e.message);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-worker-pool",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "dependencies": {
     "q": "~0.9.7"
   },


### PR DESCRIPTION
I'm switching to native promises for jest. Promise doesn't have done + I think this is a bad place to call `done` because there are already error handlers in place that bubble up.